### PR TITLE
Using get_site_url to determine current page url. This fixes multisite pagination

### DIFF
--- a/index.php
+++ b/index.php
@@ -166,8 +166,9 @@ function afg_display_gallery($atts) {
     if ($request_uri == '' || !$request_uri) $request_uri = $_SERVER['REQUEST_URI'];
 
     $cur_page = 1;
-    $cur_page_url = ( isset($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS'] == 'on') || $_SERVER['HTTPS'] == '1') ) ? "https://".$_SERVER['SERVER_NAME'].$request_uri : "http://".$_SERVER['SERVER_NAME'].$request_uri;
-    $cur_page_url = preg_replace("/hilbert-in.com/", "pkhs.nl", $cur_page_url);
+
+    $cur_page_url = get_site_url(NULL, $request_uri);
+
     preg_match("/afg{$id}_page_id=(?P<page_id>\d+)/", $cur_page_url, $matches);
 
     if ($matches) {


### PR DESCRIPTION
I've run across an issue with the generation of pagination links. This patch fixes it in a multisite network based on subdomains. It has not been tested with other configurations and relies on a function introducted in wp 3.0
