### PR TITLE
Urlencode the links output by the code

### DIFF
--- a/afg_libs.php
+++ b/afg_libs.php
@@ -173,7 +173,7 @@ function afg_get_photo_url($farm, $server, $pid, $secret, $size) {
     if ($size == 'NULL') {
         $size = '';
     }
-    return "http://farm$farm.static.flickr.com/$server/{$pid}_$secret$size.jpg";
+    return urlencode("http://farm$farm.static.flickr.com/$server/{$pid}_$secret$size.jpg");
 }
 
 function afg_get_photo_page_url($pid, $uid) {


### PR DESCRIPTION
If we don't urlencode the links output, then the malformed urls generated can trip up web firewalls.

there are probably other places in the code where this is an issue, but I don't want to touch them unless you think this is the right approach.  If so, just let me know and I can add the other ones.
