### PR TITLE
Correct URL encoding issue in afg_get_photo_url

### DIFF
--- a/afg_libs.php
+++ b/afg_libs.php
@@ -173,7 +173,7 @@ function afg_get_photo_url($farm, $server, $pid, $secret, $size) {
     if ($size == 'NULL') {
         $size = '';
     }
-    return urlencode("http://farm$farm.static.flickr.com/$server/{$pid}_$secret$size.jpg");
+    return "http://farm".urlencode($farm).".static.flickr.com/".urlencode($server)."/".urlencode($pid)."_".urlencode($secret).urlencode($size).".jpg";
 }
 
 function afg_get_photo_page_url($pid, $uid) {


### PR DESCRIPTION
The existing code caused thumbnails not to be displayed. The existing code nonsensically attempted to URL encode the "http://" portion of the URL. This change wraps the individual parameters with the URLencode() function while allowing the known protocol and URI control characters to pass through unescaped.
