### PR TITLE
New option so user can choose flickr tag matching is "any" or "all"

### DIFF
--- a/afg_add_galleries.php
+++ b/afg_add_galleries.php
@@ -51,8 +51,10 @@ function afg_add_gallery() {
                 $gallery['gallery_id'] = $_POST['afg_galleries_box'];
             else if ($_POST['afg_photo_source_type'] == 'group')
                 $gallery['group_id'] = $_POST['afg_groups_box'];
-            else if ($_POST['afg_photo_source_type'] == 'tags')
+            else if ($_POST['afg_photo_source_type'] == 'tags') {
                 $gallery['tags'] = $_POST['afg_tags'];
+                $gallery['tag_mode'] = $_POST['afg_tag_mode'];
+            }
 
             if ($gallery['photo_size'] == 'custom') {
                 if (ctype_digit($_POST['afg_custom_size']) && (int)$_POST['afg_custom_size'] >= 50 && (int)$_POST['afg_custom_size'] <= 500) {

--- a/afg_edit_galleries.php
+++ b/afg_edit_galleries.php
@@ -35,7 +35,7 @@ if (isset($_POST['afg_edit_gallery_name']) && $_POST['afg_edit_gallery_name']) {
     if ($_POST['afg_photo_source_type'] == 'photoset') $gallery['photoset_id'] = $_POST['afg_photosets_box'];
     else if ($_POST['afg_photo_source_type'] == 'gallery') $gallery['gallery_id'] = $_POST['afg_galleries_box'];
     else if ($_POST['afg_photo_source_type'] == 'group') $gallery['group_id'] = $_POST['afg_groups_box'];
-    else if ($_POST['afg_photo_source_type'] == 'tags') $gallery['tags'] = $_POST['afg_tags'];
+    else if ($_POST['afg_photo_source_type'] == 'tags') { $gallery['tags'] = $_POST['afg_tags']; $gallery['tag_mode'] = $_POST['afg_tag_mode']; }
 
     if ($gallery['photo_size'] == 'custom') {
         if (ctype_digit($_POST['afg_custom_size']) && (int)$_POST['afg_custom_size'] >= 50 && (int)$_POST['afg_custom_size'] <= 500) {

--- a/afg_libs.php
+++ b/afg_libs.php
@@ -3,7 +3,12 @@ define('PLUGIN_SLUG', 'awesome-flickr-gallery-plugin');
 define('BASE_URL', plugins_url() . '/' . basename(dirname(__FILE__)));
 define('SITE_URL', site_url());
 define('DEBUG', false);
-define('VERSION', '3.5.1');
+define('VERSION', '3.5.2');
+
+$afg_tag_mode_map = array(
+    'any' => 'Any tag matches',
+    'all' => 'All tags must match',
+);
 
 $afg_sort_order_map = array(
     'default' => 'Default',
@@ -273,6 +278,7 @@ function afg_generate_version_line() {
 
 function afg_generate_flickr_settings_table($photosets, $galleries, $groups) {
     global $afg_photo_source_map;
+    global $afg_tag_mode_map;
     $photosets = afg_generate_options($photosets, '', False);
     $galleries = afg_generate_options($galleries, '', False);
     $groups = afg_generate_options($groups, '', False);
@@ -298,8 +304,11 @@ function afg_generate_flickr_settings_table($photosets, $galleries, $groups) {
         <select style='display:none' name='afg_groups_box' id='afg_groups_box'>$groups
         </select>
         <textarea rows='3' cols='30' name='afg_tags' id='afg_tags' style='display:none'></textarea>
+        <p><select style='display:none' name='afg_tag_mode' id='afg_tag_mode'>" . afg_generate_options($afg_tag_mode_map, 'any', False) . "
+        </select>
         </td>
-        <td id='afg_source_help' class='afg-help-bubble' style='display:none'>Enter tags separated by comma. For example: <b>tag1, tag2, tag3, tag4</b><br />Photos matching any of the given tags will be displayed.</td>
+        <td id='afg_source_help' class='afg-help-bubble' style='display:none'>Enter tags separated by comma. For example: <b>tag1, tag2, tag3, tag4</b>
+        <p><br />Choose whether photos matching <i>any</i> of the given tags will be displayed, or whether they must match <i>all</i> the given tags.</td>
         </tr>
     </table>";
 }

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
    Plugin Name: Awesome Flickr Gallery
    Plugin URI: http://www.ronakg.com/projects/awesome-flickr-gallery-wordpress-plugin/
    Description: Awesome Flickr Gallery is a simple, fast and light plugin to create a gallery of your Flickr photos on your WordPress enabled website.  This plugin aims at providing a simple yet customizable way to create stunning Flickr gallery.
-   Version: 3.5.1
+   Version: 3.5.2
    Author: Ronak Gandhi
    Author URI: http://www.ronakg.com
    License: GPL2
@@ -200,6 +200,7 @@ function afg_display_gallery($atts) {
     $gallery_id = NULL;
     $group_id = NULL;
     $tags = NULL;
+    $tag_mode = NULL;
     $popular = false;
 
     if (!isset($gallery['photo_source'])) $gallery['photo_source'] = 'photostream';
@@ -207,7 +208,7 @@ function afg_display_gallery($atts) {
     if ($gallery['photo_source'] == 'photoset') $photoset_id = $gallery['photoset_id'];
     else if ($gallery['photo_source'] == 'gallery') $gallery_id = $gallery['gallery_id'];
     else if ($gallery['photo_source'] == 'group') $group_id = $gallery['group_id'];
-    else if ($gallery['photo_source'] == 'tags') $tags = $gallery['tags'];
+    else if ($gallery['photo_source'] == 'tags') { $tags = $gallery['tags']; $tag_mode = $gallery['tag_mode']; }
     else if ($gallery['photo_source'] == 'popular') $popular = true;
 
     $disp_gallery = "<!-- Awesome Flickr Gallery Start -->";
@@ -218,6 +219,7 @@ function afg_display_gallery($atts) {
         " - Gallery ID - " . (isset($gallery_id)? $gallery_id: '') .
         " - Group ID - " . (isset($group_id)? $group_id: '') .
         " - Tags - " . (isset($tags)? $tags: '') .
+        " - Tag mode - " . (isset($tag_mode)? $tag_mode: '') .
         " - Popular - " . (isset($popular)? $popular: '') .
         " - Per Page - " . $per_page .
         " - Sort Order - " . $sort_order .
@@ -261,7 +263,7 @@ function afg_display_gallery($atts) {
             if ($total_photos > 500) $total_photos = 500;
             }
         else if (isset($tags) && $tags) {
-            $rsp_obj = $pf->photos_search(array('user_id'=>$user_id, 'tags'=>$tags, 'extras'=>$extras, 'per_page'=>1));
+            $rsp_obj = $pf->photos_search(array('user_id'=>$user_id, 'tags'=>$tags, 'tag_mode'=>$tag_mode,'extras'=>$extras, 'per_page'=>1));
             if ($pf->error_code) return afg_error($pf->error_msg);
             $total_photos = $rsp_obj['photos']['total'];
         }
@@ -294,7 +296,7 @@ function afg_display_gallery($atts) {
             }
             else if ($tags) {
                 $flickr_api = 'photos';
-                $rsp_obj_total = $pf->photos_search(array('user_id'=>$user_id, 'tags'=>$tags, 'extras'=>$extras, 'per_page'=>500, 'page'=>$i));
+                $rsp_obj_total = $pf->photos_search(array('user_id'=>$user_id, 'tags'=>$tags, 'tag_mode'=>$tag_mode, 'extras'=>$extras, 'per_page'=>500, 'page'=>$i));
                 if ($pf->error_code) return afg_error($pf->error_msg);
             }
             else if ($popular) {

--- a/js/afg_edit_galleries.js
+++ b/js/afg_edit_galleries.js
@@ -1,3 +1,4 @@
+
 mjson = jQuery.noConflict();
 
 mjson(document).ready(function(){
@@ -70,6 +71,7 @@ function getPhotoSourceType() {
     var galleries_box = document.getElementById('afg_galleries_box');
     var groups_box = document.getElementById('afg_groups_box');
     var tags_box = document.getElementById('afg_tags');
+    var tag_mode_box = document.getElementById('afg_tag_mode');
     var source_label = document.getElementById('afg_photo_source_label');
     var help_text = document.getElementById('afg_source_help');
 
@@ -79,6 +81,7 @@ function getPhotoSourceType() {
         galleries_box.style.display = 'none';
         groups_box.style.display = 'none';
         tags_box.style.display = 'none';
+        tag_mode_box.style.display = 'none';
         help_text.style.display = 'none';
     }
     else if (source_element.value == 'gallery') {
@@ -93,6 +96,7 @@ function getPhotoSourceType() {
             photosets_box.style.display = 'none';
             groups_box.style.display = 'none';
             tags_box.style.display = 'none';
+            tag_mode_box.style.display = 'none';
             help_text.style.display = 'none';
             source_label.innerHTML = 'Select Gallery';
         }
@@ -109,6 +113,7 @@ function getPhotoSourceType() {
             galleries_box.style.display = 'none';
             groups_box.style.display = 'none';
             tags_box.style.display = 'none';
+            tag_mode_box.style.display = 'none';
             help_text.style.display = 'none';
             source_label.innerHTML = "Select Photoset";
         }
@@ -125,6 +130,7 @@ function getPhotoSourceType() {
             galleries_box.style.display = 'none';
             groups_box.style.display = 'block';
             tags_box.style.display = 'none';
+            tag_mode_box.style.display = 'none';
             help_text.style.display = 'none';
             source_label.innerHTML = "Select Group";
         }
@@ -135,6 +141,7 @@ function getPhotoSourceType() {
         galleries_box.style.display = 'none';
         groups_box.style.display = 'none';
         tags_box.style.display = 'block';
+        tag_mode_box.style.display = 'block';
         help_text.style.display = 'block';
         source_label.innerHTML = "Tags";
     }
@@ -158,6 +165,7 @@ function loadGallerySettings() {
     var galleries_box = document.getElementById('afg_galleries_box');
     var groups_box = document.getElementById('afg_groups_box');
     var tags_box = document.getElementById('afg_tags');
+    var tag_mode_box = document.getElementById('afg_tag_mode');
     var source_label = document.getElementById('afg_source_label');
     var per_page = document.getElementById('afg_per_page');
     var sort_order = document.getElementById('afg_sort_order');
@@ -226,21 +234,25 @@ function loadGallerySettings() {
         /*galleries_box.value = '';*/
         /*groups_box.value = '';*/
         /*tags_box.value = '';*/
+        /*tag_mod_box.value = '';*/
     }
     else if (source_element.value == 'gallery') {
         galleries_box.value = active_gallery.gallery_id;
         /*photosets_box.value = '';*/
         /*groups_box.value = '';*/
         /*tags_box.value = '';*/
+        /*tag_mod_box.value = '';*/
     }
     else if (source_element.value == 'group') {
         groups_box.value = active_gallery.group_id;
         /*photosets_box.value = '';*/
         /*galleries_box.value = '';*/
         /*tags_box.value = '';*/
+        /*tag_mod_box.value = '';*/
     }
     else if (source_element.value == 'tags') {
         tags_box.value = active_gallery.tags;
+        tag_mode_box.value = active_gallery.tag_mode;
         /*photosets_box.value = '';*/
         /*galleries_box.value = '';*/
         /*groups_box.value = '';*/


### PR DESCRIPTION
Hi, like your flickr gallery plugin for wordpress. However I really wanted to be able to build a gallery based on matching "all" tags, not "any" tag that matches out of the list.

This pull request is a modification to add an option to the plugin to allow exactly that. It is user configurable on a per-gallery basis.
