### PR TITLE
Fix broken "Add Galleries" link in side box

### DIFF
--- a/afg_admin_settings.php
+++ b/afg_admin_settings.php
@@ -458,7 +458,7 @@ if ($_POST)
     echo afg_box('Help', $message);
 
     $message = "Just insert the code <strong><font color='steelblue'>[AFG_gallery]</font></strong> in any of your posts or pages to display the Awesome Flickr Gallery.
-        <br /><p style='text-align:center'><i>-- OR --</i></p>You can create a new Awesome Flickr Gallery with different settings on page <a href='{$_SERVER['PHP_SELF']}?page=afg_add_gallery_page'>Add Galleries.";
+        <br /><p style='text-align:center'><i>-- OR --</i></p>You can create a new Awesome Flickr Gallery with different settings on page <a href='" . get_admin_url() . "admin.php?page=afg_add_gallery_page'?page=afg_add_gallery_page'>Add Galleries.";
     echo afg_box('Usage Instructions', $message);
 
     echo afg_donate_box();


### PR DESCRIPTION
**[Issue](https://github.com/ronakg/awesome-flickr-gallery-plugin/issues/88)**
The "Add Galleries" link in the side box is broken when viewed from `/wp-admin/plugins.php`. It works when viewed from `/wp-admin/admin.

**Fix**
Instead of `/wp-admin/plugins.php?page=afg_add_gallery_page`, it should be `/wp-admin/admin.php?page=afg_add_gallery_page`. You could make it an absolute link rather than relative.

![image](https://cloud.githubusercontent.com/assets/1975098/20651096/3e8063d8-b4d6-11e6-8e1e-6e7836e4719a.png)
